### PR TITLE
Check for hash_hkdf instead of hkdf

### DIFF
--- a/src/hash_hkdf.php
+++ b/src/hash_hkdf.php
@@ -29,7 +29,7 @@
  * @license	http://opensource.org/licenses/ISC ISC License (ISC)
  * @link	https://github.com/narfbg/hash_hkdf_compat
  */
-if ( ! function_exists('hkdf'))
+if ( ! function_exists('hash_hkdf'))
 {
 	/**
 	 * hash_hkdf()


### PR DESCRIPTION
Maybe I'm missing something obvious here, but shouldn't we be checking for `hash_hkdf` in < 7.1.2 instead of `hkdf`? `hkdf` isn't defined in `7.1.2`, meaning that this will always be loaded over the native implementation.

```bash
# PHP 7.1.2
$ php --version
PHP 7.1.2 (cli) (built: Feb 18 2017 16:03:58) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.1.0, Copyright (c) 1998-2017 Zend Technologies

# Hash is enabled
$ php -m | grep hash
hash

# HKDF isn't a function, hash_hkdf is
$ php -a
Interactive shell

php > var_dump(function_exists('hkdf'));
bool(false)
```